### PR TITLE
Fix bug in CommandResult UI, and EditApplicant

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -56,6 +56,13 @@ public class CommandResult {
     }
 
     /**
+     * Constructs a {@code CommandResult} that makes appropriate changes to UI
+     */
+    public CommandResult(String feedbackToUser, boolean tabApplicant, boolean tabJob, boolean resetPanel) {
+        this(feedbackToUser, false, false, tabApplicant, tabJob, resetPanel);
+    }
+
+    /**
      * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
      * and other fields set to their default value.
      */

--- a/src/main/java/seedu/address/logic/commands/applicant/AddApplicant.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/AddApplicant.java
@@ -62,7 +62,7 @@ public class AddApplicant extends Command {
         }
 
         model.addApplicant(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), true, false, true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/applicant/DeleteApplicant.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/DeleteApplicant.java
@@ -50,7 +50,8 @@ public class DeleteApplicant extends Command {
 
         Applicant applicantToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteApplicant(applicantToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_APPLICANT_SUCCESS, applicantToDelete));
+        return new CommandResult(String.format(MESSAGE_DELETE_APPLICANT_SUCCESS, applicantToDelete), true,
+                false, true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/applicant/EditApplicant.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/EditApplicant.java
@@ -106,7 +106,8 @@ public class EditApplicant extends Command {
 
         model.setApplicant(applicantToEdit, editedApplicant);
         model.updateFilteredApplicantList(PREDICATE_SHOW_ALL_APPLICANTS);
-        return new CommandResult(String.format(MESSAGE_EDIT_APPLICANT_SUCCESS, editedApplicant));
+        return new CommandResult(String.format(MESSAGE_EDIT_APPLICANT_SUCCESS, editedApplicant), true, false,
+                true);
     }
 
     /**
@@ -137,7 +138,7 @@ public class EditApplicant extends Command {
 
         LocalDate dateApplied = updatedDateApplied.date;
         LocalDate interviewDate = updatedInterviewDate.date;
-        if (interviewDate.compareTo(dateApplied) < 0) {
+        if (interviewDate.compareTo(dateApplied) < 0 && updatedInterviewDate.isInit) {
             throw new CommandException(MESSAGE_DATE_APPLIED_LATER_THAN_INTERVIEW_DATE);
         }
 

--- a/src/main/java/seedu/address/logic/commands/applicant/FindApplicant.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/FindApplicant.java
@@ -33,7 +33,8 @@ public class FindApplicant extends Command {
         requireNonNull(model);
         model.updateFilteredApplicantList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_APPLICANTS_LISTED_OVERVIEW, model.getFilteredApplicantList().size()));
+                String.format(Messages.MESSAGE_APPLICANTS_LISTED_OVERVIEW, model.getFilteredApplicantList().size()),
+                true, false, false);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/applicant/MarkApplicant.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/MarkApplicant.java
@@ -62,7 +62,8 @@ public class MarkApplicant extends Command {
 
         model.setApplicant(applicantToMark, markedApplicant);
         model.updateFilteredApplicantList(PREDICATE_SHOW_ALL_APPLICANTS);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, applicantToMark, applicantStatus));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, applicantToMark, applicantStatus), true, false,
+                true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/job/AddJob.java
+++ b/src/main/java/seedu/address/logic/commands/job/AddJob.java
@@ -27,7 +27,7 @@ public class AddJob extends Command {
             + PREFIX_JOB_POSITION + "POSITION "
             + PREFIX_SALARY + "SALARY "
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_JOBTITLE + "Software Developer "
+            + PREFIX_JOBTITLE + "Devops Engineer "
             + PREFIX_COMPANY_NAME + "Ebiz Pte Ltd "
             + PREFIX_ADDRESS + "59 Hougang Road Blk 38 "
             + PREFIX_QUALIFICATION + "Bachelors in Computer Science "
@@ -60,7 +60,7 @@ public class AddJob extends Command {
                 toAdd.getAddress(), toAdd.getQualification(), toAdd.getJobStatus(), toAdd.getPosition(),
                 toAdd.getSalary());
         model.addJob(jobWithId);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, jobWithId));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, jobWithId), false, true, true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/job/DeleteJob.java
+++ b/src/main/java/seedu/address/logic/commands/job/DeleteJob.java
@@ -45,7 +45,7 @@ public class DeleteJob extends Command {
 
         Job jobToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteJob(jobToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_JOB_SUCCESS, jobToDelete));
+        return new CommandResult(String.format(MESSAGE_DELETE_JOB_SUCCESS, jobToDelete), false, true, true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/job/EditJob.java
+++ b/src/main/java/seedu/address/logic/commands/job/EditJob.java
@@ -89,7 +89,7 @@ public class EditJob extends Command {
 
         model.setJob(jobToEdit, editedJob);
         model.updateFilteredJobList(PREDICATE_SHOW_ALL_JOBS);
-        return new CommandResult(String.format(MESSAGE_EDIT_JOB_SUCCESS, editedJob));
+        return new CommandResult(String.format(MESSAGE_EDIT_JOB_SUCCESS, editedJob), false, true, true);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/job/FindJob.java
+++ b/src/main/java/seedu/address/logic/commands/job/FindJob.java
@@ -45,7 +45,8 @@ public class FindJob extends Command {
         requireNonNull(model);
         model.updateFilteredJobList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_JOBS_LISTED_OVERVIEW, model.getFilteredJobList().size()));
+                String.format(Messages.MESSAGE_JOBS_LISTED_OVERVIEW, model.getFilteredJobList().size()), false, true,
+                false);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/job/MarkJob.java
+++ b/src/main/java/seedu/address/logic/commands/job/MarkJob.java
@@ -66,7 +66,7 @@ public class MarkJob extends Command {
         model.setJob(toMark, markedJob);
         model.updateFilteredJobList(PREDICATE_SHOW_ALL_JOBS);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, markedJob));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, markedJob), false, true, true);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/applicant/InterviewDate.java
+++ b/src/main/java/seedu/address/model/applicant/InterviewDate.java
@@ -21,7 +21,7 @@ public class InterviewDate implements Comparable<InterviewDate> {
      */
     public static final String VALIDATION_REGEX = "^[0-9]{4}-(1[0-2]|0[1-9])-(3[01]|[12][0-9]|0[1-9])$";
     public final LocalDate date;
-    private final boolean isInit;
+    public final boolean isInit;
 
     /**
      * Constructs an Interview Date

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -13,6 +13,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
 import seedu.address.storage.JsonAddressBookStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.StorageManager;
@@ -88,9 +90,10 @@ public class LogicManagerTest {
         // Execute add command
         String addCommand = AddApplicant.COMMAND_WORD + NAME_DESC_AMY + " nric/ " + DEFAULT_NRIC
                 + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + " d/" + "2022-03-08";
+        Set<Tag> tagSet = new HashSet<>();
         Applicant expectedApplicant = new Applicant(new Name("Amy Bee"), new Phone("11111111"),
                 new Email("amy@example.com"), new Address("Block 312, Amy Street 1"),
-                new HashSet(), new DateApplied("2022-03-08"), new Nric("S9901010A"));
+                tagSet, new DateApplied("2022-03-08"), new Nric("S9901010A"));
         ModelManager expectedModel = new ModelManager();
         expectedModel.addApplicant(expectedApplicant);
         String expectedMessage = LogicManager.FILE_OPS_ERROR_MESSAGE + DUMMY_IO_EXCEPTION;

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -212,6 +212,17 @@ public class CommandTestUtil {
     }
 
     /**
+     * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandResult, Model)}
+     * that takes a string {@code expectedMessage} and UI changes.
+     */
+    public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
+                                            boolean tabApplicant, boolean tabJob, boolean resetPanel,
+                                            Model expectedModel) {
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, tabApplicant, tabJob, resetPanel);
+        assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
+    }
+
+    /**
      * Executes the given {@code command}, confirms that <br>
      * - a {@code CommandException} is thrown <br>
      * - the CommandException message matches {@code expectedMessage} <br>

--- a/src/test/java/seedu/address/logic/commands/applicant/DeleteApplicantTest.java
+++ b/src/test/java/seedu/address/logic/commands/applicant/DeleteApplicantTest.java
@@ -33,7 +33,7 @@ class DeleteApplicantTest {
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteApplicant(applicantToDelete);
 
-        assertCommandSuccess(deleteApplicant, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deleteApplicant, model, expectedMessage, true, false, true, expectedModel);
     }
 
     @Test
@@ -59,7 +59,7 @@ class DeleteApplicantTest {
         expectedModel.deleteApplicant(applicantToDelete);
         showNoApplicant(expectedModel);
 
-        assertCommandSuccess(deleteApplicant, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deleteApplicant, model, expectedMessage, true, false, true, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/applicant/EditApplicantTest.java
+++ b/src/test/java/seedu/address/logic/commands/applicant/EditApplicantTest.java
@@ -42,7 +42,7 @@ class EditApplicantTest {
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setApplicant(model.getFilteredApplicantList().get(0), editedApplicant);
 
-        assertCommandSuccess(editApplicant, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editApplicant, model, expectedMessage, true, false, true, expectedModel);
     }
 
     @Test
@@ -63,7 +63,7 @@ class EditApplicantTest {
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setApplicant(lastApplicant, editedApplicant);
 
-        assertCommandSuccess(editApplicant, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editApplicant, model, expectedMessage, true, false, true, expectedModel);
     }
 
     @Test
@@ -76,7 +76,7 @@ class EditApplicantTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
-        assertCommandSuccess(editApplicant, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editApplicant, model, expectedMessage, true, false, true, expectedModel);
     }
 
     @Test
@@ -93,7 +93,7 @@ class EditApplicantTest {
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setApplicant(model.getFilteredApplicantList().get(0), editedApplicant);
 
-        assertCommandSuccess(editApplicant, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editApplicant, model, expectedMessage, true, false, true, expectedModel);
     }
 
     @Test
@@ -164,7 +164,7 @@ class EditApplicantTest {
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setApplicant(firstApplicant, editedApplicant);
 
-        assertCommandSuccess(editApplicant, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editApplicant, model, expectedMessage, true, false, true, expectedModel);
     }
 
     /**
@@ -187,7 +187,7 @@ class EditApplicantTest {
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setApplicant(firstApplicant, editedApplicant);
 
-        assertCommandSuccess(editApplicant, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editApplicant, model, expectedMessage, true, false, true, expectedModel);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/applicant/FindApplicantTest.java
+++ b/src/test/java/seedu/address/logic/commands/applicant/FindApplicantTest.java
@@ -58,7 +58,7 @@ class FindApplicantTest {
         NameApplicantContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindApplicant command = new FindApplicant(predicate);
         expectedModel.updateFilteredApplicantList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, true, false, false, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredApplicantList());
     }
 
@@ -68,7 +68,7 @@ class FindApplicantTest {
         NameApplicantContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindApplicant command = new FindApplicant(predicate);
         expectedModel.updateFilteredApplicantList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, true, false, false, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredApplicantList());
     }
 

--- a/src/test/java/seedu/address/logic/commands/applicant/MarkApplicantTest.java
+++ b/src/test/java/seedu/address/logic/commands/applicant/MarkApplicantTest.java
@@ -35,7 +35,7 @@ public class MarkApplicantTest {
         expectedModel.setApplicant(model.getFilteredApplicantList().get(INDEX_FIRST_APPLICANT.getZeroBased()),
                 applicantToMark);
 
-        assertCommandSuccess(markApplicant, model, expectedMessage, expectedModel);
+        assertCommandSuccess(markApplicant, model, expectedMessage, true, false, true, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/job/DeleteJobTest.java
+++ b/src/test/java/seedu/address/logic/commands/job/DeleteJobTest.java
@@ -33,7 +33,7 @@ class DeleteJobTest {
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteJob(jobToDelete);
 
-        assertCommandSuccess(deleteJob, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deleteJob, model, expectedMessage, false, true, true, expectedModel);
     }
 
     @Test
@@ -59,7 +59,7 @@ class DeleteJobTest {
         expectedModel.deleteJob(jobToDelete);
         showNoJob(expectedModel);
 
-        assertCommandSuccess(deleteJob, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deleteJob, model, expectedMessage, false, true, true, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/job/EditJobTest.java
+++ b/src/test/java/seedu/address/logic/commands/job/EditJobTest.java
@@ -45,7 +45,7 @@ class EditJobTest {
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setJob(model.getFilteredJobList().get(0), editedJob);
 
-        assertCommandSuccess(editJob, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editJob, model, expectedMessage, false, true, true, expectedModel);
     }
 
     @Test
@@ -67,7 +67,7 @@ class EditJobTest {
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setJob(lastJob, editedJob);
 
-        assertCommandSuccess(editJob, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editJob, model, expectedMessage, false, true, true, expectedModel);
     }
 
     @Test
@@ -80,7 +80,7 @@ class EditJobTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
-        assertCommandSuccess(editJob, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editJob, model, expectedMessage, false, true, true, expectedModel);
     }
 
     @Test
@@ -97,7 +97,7 @@ class EditJobTest {
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setJob(model.getFilteredJobList().get(0), editedJob);
 
-        assertCommandSuccess(editJob, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editJob, model, expectedMessage, false, true, true, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/job/FindJobTest.java
+++ b/src/test/java/seedu/address/logic/commands/job/FindJobTest.java
@@ -62,7 +62,7 @@ public class FindJobTest {
         NameJobContainsKeywordsPredicate predicate = preparePredicateName(" ");
         FindJob command = new FindJob(predicate);
         expectedModel.updateFilteredJobList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, false, true, false, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredJobList());
     }
 
@@ -72,7 +72,7 @@ public class FindJobTest {
         NameJobContainsKeywordsPredicate predicate = preparePredicateName("Waiter Software Engineer");
         FindJob command = new FindJob(predicate);
         expectedModel.updateFilteredJobList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, false, true, false, expectedModel);
         assertEquals(Arrays.asList(SOFTWARE_ENGINEER, ENGINEER, WAITER), model.getFilteredJobList());
     }
 
@@ -82,7 +82,7 @@ public class FindJobTest {
         JobIdSamePredicate predicate = preparePredicateID(" 1");
         FindJob command = new FindJob(predicate);
         expectedModel.updateFilteredJobList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, false, true, false, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredJobList());
     }
 
@@ -92,7 +92,7 @@ public class FindJobTest {
         JobIdSamePredicate predicate = preparePredicateID("3");
         FindJob command = new FindJob(predicate);
         expectedModel.updateFilteredJobList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, false, true, false, expectedModel);
         assertEquals(Arrays.asList(SOFTWARE_ENGINEER), model.getFilteredJobList());
     }
 


### PR DESCRIPTION
1) Fix bug in the results of the add, delete, edit, mark and find commands for both Applicants and jobs, where executing of command would not reflect any changes in the UI, and would not switch to the correct tab. Now all commands will switch to their respective tabs and refresh the list.

2) Previous bug fix for edit applicant introduced a new bug where any applicant with their InterviewDate in a "Pending" state could not be edited because it checked 
```
if (interviewDate.compareTo(dateApplied) ) {
            throw new CommandException(MESSAGE_DATE_APPLIED_LATER_THAN_INTERVIEW_DATE);
        }
```

Since all pending InterviewDate has a placeholder LocalDate of 1999-01-19, any editapplicant command will throw an exception unless the DateApplied is before 1999-01-19. Fixed by checking if the InterviewDate object is Initialised. (isInit).