### PR TITLE
UG: Fixed inconsistency in markapplicant

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -287,7 +287,7 @@ Format: `markapplicant *[INDEX] *s/[STATUS]`
 `[INDEX*]` : Index number for the applicant on the applicant list. The index should be a positive integer 1, 2, 3...
 
 `s/[STATUS]`: Flag to mark the applicant status of the applicant. `[STATUS]` must be either
-pending, accepted, or rejected
+`pending`, `interviewed`, `accepted`, or `rejected`.
 
 **Tip:** Fill in fields in the stipulated order. To leave out optional fields, skip the flag and attribute completely.
 


### PR DESCRIPTION
Added 'interviewed' status to markapplicant attribute description (previously only had 'accepted', 'pending', and 'rejected'