### PR TITLE
Set limit to phone number to maximum 15 digits

### DIFF
--- a/src/main/java/seedu/address/logic/commands/applicant/AddApplicant.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/AddApplicant.java
@@ -59,7 +59,7 @@ public class AddApplicant extends Command {
         requireNonNull(model);
 
         if (model.hasApplicant (toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_APPLICANT );
+            throw new CommandException(MESSAGE_DUPLICATE_APPLICANT);
         }
 
         model.addApplicant(toAdd);

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -12,7 +12,7 @@ public class Phone {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+    public static final String VALIDATION_REGEX = "\\d{3,15}";
     public final String value;
 
     /**

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -31,10 +31,11 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
+        assertFalse(Phone.isValidPhone("1234567890123456")); //phone number more than 15 digits
 
         // valid phone numbers
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
         assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("123456789012345")); // long phone numbers, 15 digits
     }
 }


### PR DESCRIPTION
Maximum phone number length imposed by The [International Telecommunication Union] is 15 digits.
[https://en.wikipedia.org/wiki/Telephone_numbering_plan#:~:text=The%20International%20Telecommunication%20Union%20(ITU,15%20digits%20to%20telephone%20numbers.](url)